### PR TITLE
Readthedocs incorporation for testing website builds

### DIFF
--- a/.github/workflows/generate_website_pr.yaml
+++ b/.github/workflows/generate_website_pr.yaml
@@ -1,4 +1,4 @@
-name: Publish website to gh-pages
+name: Generate website in PR
 on:
   pull_request:
     branches:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+# install package via pip
+python:
+   install:
+       - requirements: requirements.lock


### PR DESCRIPTION
Readthedocs can be used to generate the website on PRs.
This is great for the user to check if it all works and looks like it should.
